### PR TITLE
マイページの作成

### DIFF
--- a/app/assets/stylesheets/homes_index.css
+++ b/app/assets/stylesheets/homes_index.css
@@ -1,0 +1,10 @@
+.card-size {
+ width: 200px;
+}
+
+.ranking {
+  font-size: 14px;
+}
+.bookmark {
+  font-size: 14px;
+}

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,6 +1,6 @@
 <div class="card mx-auto" style="width:700px; box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);">
   <div class="card-body">
-    <h2 class="text-center"><%=t('.title') %></h2>
+    <h1 class="text-center mb-5"><%=t('.title') %></h1>
     <div class="d-flex justify-content-center">
       <div class="card me-5"style="width:150px; height:150px;">
         <div class="card-body">
@@ -15,31 +15,33 @@
         </div>
       </div>
     </div>
-    <div class="d-flex justify-content-center">
+    <div class="d-flex justify-content-center mb-3">
       <div class="card me-5">
-        <div class="card-body ranking-size">
+        <div class="card-body card-size">
           <div class="text-center">
             <i class="fa-solid fa-crown fa-4x mb-3" style="color:yellow;"></i>
           </div>
-          <p class="text-center mb-3"><strong><%= t('.ranking')%></strong></p>
+          <p class="text-center mb-3"><%= link_to t('.ranking')%></p>
           <p class="ranking text-center">さまざまなランキングを見ることができるよ</p>
         </div>
       </div>
       <div class="card">
-        <div class="card-body bookmark-size">
+        <div class="card-body card-size">
           <div class="text-center mb-3">
            <i class="fa-solid fa-heart fa-4x" style="color:pink;"></i>
           </div>
-          <p class="text-center mb-3"><strong>お気に入りページ</strong></p>
+          <p class="text-center mb-3"><%= link_to t('.bookmark') %></p>
           <p class="bookmark text-center">いいねをつけたお店を確認できるよ</p>
         </div>
       </div>
     </div>
-    <div class="card">
-      <div class="card-body text-center search-size">
-        <i class="fa-brands fa-searchengin fa-4x mb-3 " style="color:blue;" ></i>
-        <p class="mb-3"><strong>検索ページ</strong></p>
-        <p class="mb-3">居酒屋を検索することができるよ</p>
+    <div class="d-flex justify-content-center mb-3">
+      <div class="card card-size">
+        <div class="card-body text-center">
+          <i class="fa-brands fa-searchengin fa-4x mb-3 " style="color:blue;" ></i>
+          <p class="mb-3"><%= link_to t('.search') %></p>
+          <p class="mb-3">居酒屋を検索することができるよ</p>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,2 +1,46 @@
-<h1>マイページ</h1>
-<%= link_to 'ログアウト', destroy_user_session_path, data:{ turbo_method: :delete } %>
+<div class="card mx-auto" style="width:700px; box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);">
+  <div class="card-body">
+    <h2 class="text-center"><%=t('.title') %></h2>
+    <div class="d-flex justify-content-center">
+      <div class="card me-5"style="width:150px; height:150px;">
+        <div class="card-body">
+          <p class="text-center">画像</p>
+        </div>
+      </div>
+      <div class="card mb-3" style="width:350px; height: 150px;">
+        <div class="card-body">
+          <h3 class="text-center"><%= t('.user_date')%></h3>
+          <P class="mb-3"><%= User.human_attribute_name(:name) %>: <%= current_user.name%></p>
+          <p><%= User.human_attribute_name(:email) %>: <%= current_user.email%></p>
+        </div>
+      </div>
+    </div>
+    <div class="d-flex justify-content-center">
+      <div class="card me-5">
+        <div class="card-body ranking-size">
+          <div class="text-center">
+            <i class="fa-solid fa-crown fa-4x mb-3" style="color:yellow;"></i>
+          </div>
+          <p class="text-center mb-3"><strong><%= t('.ranking')%></strong></p>
+          <p class="ranking text-center">さまざまなランキングを見ることができるよ</p>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-body bookmark-size">
+          <div class="text-center mb-3">
+           <i class="fa-solid fa-heart fa-4x" style="color:pink;"></i>
+          </div>
+          <p class="text-center mb-3"><strong>お気に入りページ</strong></p>
+          <p class="bookmark text-center">いいねをつけたお店を確認できるよ</p>
+        </div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-body text-center search-size">
+        <i class="fa-brands fa-searchengin fa-4x mb-3 " style="color:blue;" ></i>
+        <p class="mb-3"><strong>検索ページ</strong></p>
+        <p class="mb-3">居酒屋を検索することができるよ</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,9 @@
     <%# bootstrap %>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
 
+    <%# font-awesome%>
+    <script src="https://kit.fontawesome.com/b9d8e59e70.js" crossorigin="anonymous"></script>
+
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -23,3 +23,5 @@ ja:
       title: マイページ
       user_date: ユーザー情報
       ranking: ランキングページ
+      bookmark: お気に入りページ
+      search: 検索ページ

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -18,3 +18,8 @@ ja:
       new:
         title: ログイン画面
         login: ログイン
+  homes:
+    index:
+      title: マイページ
+      user_date: ユーザー情報
+      ranking: ランキングページ

--- a/db/migrate/20250201081055_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20250201081055_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_29_034312) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_01_081055) do
+  create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
   create_table "bookmarks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -39,6 +67,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_29_034312) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "bookmarks", "shops"
   add_foreign_key "bookmarks", "users"
 end


### PR DESCRIPTION
### 概要
マイページのレイアウトを以下のように作成しました
画像の表示機能に関してはまだ実装しておりません。
ランキングページ/お気に入りページ/検索ページのリンクに関しましてはそれぞれ対応するページに遷移できるようにする予定ですが、現在はリンク先を指定しておりません。

<img width="769" alt="スクリーンショット 2025-02-01 17 30 16" src="https://github.com/user-attachments/assets/ba91c077-2e2b-4d14-a2e2-29f768931854" />

---
### 修正内容
1. 'homes/index.html.erb' の作成

2. FontAwesomeの導入

---
 