### PR TITLE
ユーザー情報編集フォームの作成

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,8 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name, :avatar ])
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :name, :avatar ])
   end
 
   def after_sign_in_path_for(resource)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -45,6 +45,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
    # protected
 
+   def update_resource(resource, params)
+    resource.update_without_password(params)
+   end
    # If you have extra params to permit, append them to the sanitizer.
    # def configure_sign_up_params
    #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -29,6 +29,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
    #   super
    # end
 
+   def image_delete
+    current_user.avatar.purge
+    redirect_to edit_user_registration_path
+   end
+
    # GET /resource/cancel
    # Forces the session data which is usually expired after sign
    # in to be expired now. This is useful if the user wants to
@@ -53,6 +58,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
    # The path used after sign up.
    def after_sign_up_path_for(resource)
     flash[:notice] = "ログインに成功しました"
+    homes_path
+   end
+
+   def after_update_path_for(resource)
     homes_path
    end
 

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,43 +1,60 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<%= render "users/shared/error_messages", resource: resource %>
+<div class="d-flex align-items-center">
+  <div class="card mx-auto" style="width: 500px; box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);">
+    <div class="card-body">
+      <h2 class="text-center"><%= t('.title') %></h2>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, data: { turbo: false } }, local: true) do |f| %>
+        <div class="mb-3">
+          <%= f.label :name, class:"form-label"%>
+          <%= f.text_field :name, class:"form-control" %>
+        </div>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
+        <div class="mb-3">
+          <%= f.label :email, class:"form-label" %>
+          <%= f.email_field :email, autocomplete: "email", class:"form-control" %>
+        </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+          <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+        <% end %>
+
+        <div class="mb-3">
+          <%= f.label :password, class:"form-label" %>
+          <%= f.password_field :password, autocomplete: "new-password", class:"form-control" %>
+        </div>
+
+        <div class="mb-3">
+          <%= f.label :password_confirmation, class:"form-label" %><br />
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class:"form-control" %>
+        </div>
+
+        <div class="mb-3">
+          <%= f.label :current_password, class:"form-label" %>
+          <%= f.password_field :current_password, autocomplete: "current-password", class:"form-control" %>
+        </div>
+
+        <div class="mb-3">
+          <%= f.label :avatar, class:"form-label" %>
+          <%= f.file_field :avatar, class:"form-control" %>
+          </div>
+          <% if current_user.avatar.attached? %>
+              <p class="mu-3"><%= t('.image') %></p>
+              <p class="mu-3"><%= image_tag current_user.avatar.variant(resize_to_fit: [150,150]), class:"rounded-circle" %></p>
+              <p class="mu-3"><%= link_to t('.image_delete'), users_image_delete_path %>
+          <% end %>
+        </div>
+
+        <div class="mb-3 text-center">
+          <%= f.submit t('.update'), class:"btn btn-primary" %>
+        </div>
+        <p class="text-center"><%= link_to t('.back'), homes_path %></p>
+      <% end %>
+    </div>
   </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
+</div>
+<div class="card mx-auto" style="width: 500px; box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);">
+  <div class="card-body">
+    <p class="mb-3 text-center"><strong><%= t('.delete') %></strong></p>
+    <p class="text-center"><%= link_to t('.delete_button'), registration_path(resource_name), data: { confirm: t('.really'), turbo_confirm: t('.really') }, method: :delete, class:"btn btn-danger" %></p>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -3,7 +3,7 @@
   <div class="card mx-auto" style="width: 500px; box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);">
     <div class="card-body">
       <h2 class="text-center"><%= t('.title') %></h2>
-      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, data: { turbo: false } }, local: true) do |f| %>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
         <div class="mb-3">
           <%= f.label :name, class:"form-label"%>
           <%= f.text_field :name, class:"form-control" %>
@@ -14,29 +14,9 @@
           <%= f.email_field :email, autocomplete: "email", class:"form-control" %>
         </div>
 
-        <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-          <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-        <% end %>
-
-        <div class="mb-3">
-          <%= f.label :password, class:"form-label" %>
-          <%= f.password_field :password, autocomplete: "new-password", class:"form-control" %>
-        </div>
-
-        <div class="mb-3">
-          <%= f.label :password_confirmation, class:"form-label" %><br />
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", class:"form-control" %>
-        </div>
-
-        <div class="mb-3">
-          <%= f.label :current_password, class:"form-label" %>
-          <%= f.password_field :current_password, autocomplete: "current-password", class:"form-control" %>
-        </div>
-
         <div class="mb-3">
           <%= f.label :avatar, class:"form-label" %>
           <%= f.file_field :avatar, class:"form-control" %>
-          </div>
           <% if current_user.avatar.attached? %>
               <p class="mu-3"><%= t('.image') %></p>
               <p class="mu-3"><%= image_tag current_user.avatar.variant(resize_to_fit: [150,150]), class:"rounded-circle" %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,10 @@ Rails.application.routes.draw do
     sessions: "users/sessions",
     registrations: "users/registrations"
   }
+  devise_scope :user do
+    get "users/image_delete", to: "users/registrations#image_delete"
+  end
+
   get "homes", to: "homes#index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
### 概要
自分のユーザー情報を編集できるフォームを作成しました
プロフィール画像の追加や削除もこのフォームから行うことができます。

フォームのレイアウトは以下になります
<img width="770" alt="スクリーンショット 2025-02-02 17 20 23" src="https://github.com/user-attachments/assets/b49c1f35-5b32-4455-ade7-088ddcc4b09b" />
<img width="722" alt="スクリーンショット 2025-02-02 17 20 29" src="https://github.com/user-attachments/assets/90186a42-6a73-40e3-8d1a-60a3d29c0e09" />

現在の画像という表示欄がありますが、追加したファイルのプレビュー機能は実装できていません。
編集する前に保存されていた画像を表示しています

---
### 修正内容
1. "registration/edit.html.erb" の編集
  - レイアウトの編集
  - 現在保存されている画像の表示
    - 選択している画像のプレビューではなく、編集前に保存されていた画像の表示
  - 画像アップロードフォームの追加
    - 画像削除リンクをクリックすると保存されている画像が削除できるような機能を追加
 
2. 'application'コントローラにaccoun_updateにおけるストロングパラメータを定義
  - name: ユーザー名の追加
  - avatar: プロフィール画像の追加

3. パスワード入力なしでユーザー情報を更新できるように変更
  - 'registration'コントローラの編集
---
### 確認方法
**画像のアップロード**
1. users/edit にアクセスし、画像のファイルを選択する
2. 更新ボタンを押すとマイページに遷移し、選択した画像が表示されることを確認
**画像の削除**
1. users/edit にアクセスし、画像の削除リンクをクリックする
2. 更新ボタンを押すとマイページに遷移し、デフォルト画像が表示されることを確認