### PR TITLE
店舗詳細データに画像のURLも保存できるように修正

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -16,8 +16,9 @@ class ShopsController < ApplicationController
   end
 
   def detail
-    unless Shop.find_by(unique_number: params[:id])
-       Shop.create(
+    @shop = Shop.find_by(unique_number: params[:id])
+    unless @shop
+       @shop = Shop.create(
         unique_number: params[:id],
         name_of_shop: params[:name],
         address: params[:address],
@@ -25,7 +26,8 @@ class ShopsController < ApplicationController
         access: params[:access],
         opening_hours: params[:open],
         closing_day: params[:close],
-        budget: params[:budget]
+        budget: params[:budget],
+        image: params[:logo_image]
       )
     end
   end

--- a/db/migrate/20250211030107_add_image_to_shops.rb
+++ b/db/migrate/20250211030107_add_image_to_shops.rb
@@ -1,0 +1,5 @@
+class AddImageToShops < ActiveRecord::Migration[8.0]
+  def change
+    add_column :shops, :image, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_10_080902) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_11_030107) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -61,6 +61,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_10_080902) do
     t.string "number_of_seats"
     t.text "url"
     t.string "unique_number"
+    t.text "image"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|


### PR DESCRIPTION
### 概要
店舗の詳細情報に画像のURLの保存ができるように修正し、詳細ページで店舗画像が表示できるように変更しました

---
### 修正内容
1. 'Shops'テーブルに'image'カラムの追加

2. 'shops'コントローラの'detail'アクションの修正
  - imageカラムに店舗写真のURLの保存処理を追加
  - ビューで店舗詳細情報を利用できるようにインスタンス変数を作成

---
