### PR TITLE
検索店舗詳細ページに検索ページへ戻るリンクを追加

### DIFF
--- a/app/assets/stylesheets/shops_detail.css
+++ b/app/assets/stylesheets/shops_detail.css
@@ -35,6 +35,12 @@
   border-radius: 8px;
   box-shadow: 0 4px 9px rgba(0,0,0,0.1);
   margin-top: 40px;
+}
+
+.back-link {
+  margin: 0 auto;
+  width:700px;
+  text-align: right;
   margin-bottom: 40px;
-  padding-bottom: 20px;
+  margin-top: 10px;
 }

--- a/app/views/shops/detail.html.erb
+++ b/app/views/shops/detail.html.erb
@@ -68,3 +68,6 @@
     </div>
   </div>
 </div>
+<div class="back-link">
+  <%= link_to t('.back'), shops_path %>
+</div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -51,6 +51,7 @@ ja:
       budget: 予算
       number_of_seats: 席数
       url: ホームページ
+      back: 検索ページに戻る
       
 
   views:


### PR DESCRIPTION
### 概要
店舗詳細ページの下部に検索ページへ遷移するリンクを以下のように追加しました

<img width="1408" alt="スクリーンショット 2025-02-11 17 28 29" src="https://github.com/user-attachments/assets/95343f51-b6ab-4f29-848e-de39b1fbfbac" />

---

### 確認方法
/shops にアクセスし、ページ下部にある"検索ページに戻る"リンクをクリックすると検索ページに遷移することを確認