### PR TITLE
APIリクエストとデータベース検索の条件分岐を実装

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,29 +1,70 @@
 class ShopsController < ApplicationController
   def index
-    params[:keyword] = "居酒屋" if params[:keyword].blank?
-    if params[:start]
-      params[:start] = params[:start].to_i * 10 + 1
-    else
-      params[:start] = 1
-    end
-    @keyword= Keyword.find_by(word: params[:keyword])
-    unless @keyword.present? && params[:start] == 1
+    params["keyword"] = "居酒屋" if params["keyword"].blank?
+    params[:start] = params[:start].to_i
+    # Keyword_filtersテーブルにこのKeywordとFilterの組み合わせのデータがあるかどうかを確認したい
+    keyword_filter = KeywordFilter.joins(:keyword, :filter)
+                                  .find_by(keywords: { word: params[:keyword] },
+                                           filters: { free_drink: params[:free_drink].to_i,
+                                                      free_food: params[:free_food].to_i,
+                                                      private_room: params[:private_room].to_i,
+                                                      course: params[:course].to_i,
+                                                      midnight: params[:midnight].to_i,
+                                                      non_smoking: params[:non_smoking].to_i
+                                                    }
+                                  )
+    # params[:start] == 0(ページ遷移の時) または同じ条件で検索しているかつ次の100件じゃない時データベースから取得
+    unless params[:start] == 0 || (params[:start] == 1 && keyword_filter.present?)
       @API_shop_data = HotpepperApi.search_shops(**search_params)
-      word = params[:keyword]
-      @keyword = Keyword.create!(word: word) unless Keyword.find_by(word: word)
+      word = params["keyword"]
+      @keyword = Keyword.find_or_create_by!(word: word)
       shops_create(@keyword)
     end
-    @shops = @keyword.shops
+    filter_conditions = {}
+    filter_conditions[:free_drink] = 1 if params["free_drink"].to_i == 1
+    filter_conditions[:free_food] = 1 if params["free_food"].to_i == 1
+    filter_conditions[:private_room] = 1 if params["private_room"].to_i == 1
+    filter_conditions[:course] = 1 if params["course"].to_i == 1
+    filter_conditions[:midnight] = 1 if params["midnight"].to_i == 1
+    filter_conditions[:non_smoking] = 1 if params["non_smoking"].to_i == 1
+    @keyword = Keyword.find_by(word: params["keyword"])
+    filters = Filter.where(filter_conditions)
+    @shops = Shop.joins(:filters, :keywords)
+                    .where(filters: { id: filters.ids },
+                           keywords: { word: params["keyword"] })
     @shops = Kaminari.paginate_array(@shops).page(params[:page]).per(Shop::PAGE_NUMBER)
   end
 
   private
 
   def search_params
-    params.permit(:keyword, :start)
+    params.permit(:keyword, :start, :free_drink, :free_food, :private_room, :course, :midnight, :non_smoking)
           .to_h # ハッシュ化
           .symbolize_keys # キーを文字列からキーに変更
-          .merge(keyword: params[:keyword])
+          .merge(keyword: params[:keyword],
+                 free_drink: params[:free_drink].presence || 0,
+                 free_food: params[:free_food].presence || 0,
+                 private_room: params[:private_room].presence || 0,
+                 course: params[:course].presence || 0,
+                 midnight: params[:midnight].presence || 0,
+                 non_smoking: params[:non_smoking].presence || 0,
+                 start: params[:start].to_i
+          ).tap { |search_params| }
+  end
+
+  def filter_params
+    params.permit(:keyword, :free_drink, :free_food, :private_room, :course, :midnight, :non_smoking)
+  end
+
+  def check_box_params_convert
+    {
+      free_drink: params[:free_drink] == "あり" ? 1 : 0,
+      free_food: params[:free_food] == "あり" ? 1 : 0,
+      private_room: params[:private_room] == "あり" ? 1 : 0,
+      course: params[:course] == "あり" ? 1 : 0,
+      midnight: params[:midnight] == "営業している" ? 1 : 0,
+      non_smoking: params[:non_smoking] == "なし" ? 0 : 1
+    }
   end
 
   def shops_create(keyword)
@@ -40,36 +81,47 @@ class ShopsController < ApplicationController
           number_of_seats: shop_data["capacity"],
           url: shop_data["urls"],
           logo_image: shop_data["logo_image"],
-          image: shop_data["photo"],
-          free_drink: shop_data["free_drink"],
-          free_food: shop_data["free_food"],
-          private_room: shop_data["private_room"],
-          course: shop_data["course"],
-          midnight: shop_data["midnight"],
-          non_smoking: shop_data["non_smoking"],
-      )
-      shop = Shop.find_by(unique_number: shop_data["id"])
+          image: shop_data["photo"]
+        )
+        shop = Shop.find_by(unique_number: shop_data["id"])
       else
-      shop = Shop.create!(
-        unique_number: shop_data["id"],
-        name: shop_data["name"],
-        address: shop_data["address"],
-        phone_number: shop_data["tel"],
-        access: shop_data["access"],
-        closing_day: shop_data["close"],
-        budget: shop_data["budget"],
-        number_of_seats: shop_data["capacity"],
-        url: shop_data["urls"],
-        logo_image: shop_data["logo_image"],
-        image: shop_data["photo"],
-        free_drink: shop_data["free_drink"],
-        free_food: shop_data["free_food"],
-        private_room: shop_data["private_room"],
-        course: shop_data["course"],
-        midnight: shop_data["midnight"],
-        non_smoking: shop_data["non_smoking"],
-    )
+        shop = Shop.create!(
+          unique_number: shop_data["id"],
+          name: shop_data["name"],
+          address: shop_data["address"],
+          phone_number: shop_data["tel"],
+          access: shop_data["access"],
+          closing_day: shop_data["close"],
+          budget: shop_data["budget"],
+          number_of_seats: shop_data["capacity"],
+          url: shop_data["urls"],
+          logo_image: shop_data["logo_image"],
+          image: shop_data["photo"]
+        )
       end
+
+    # APIから取得した絞り込み条件に対応するデータを0 or 1 に変換
+    free_drink = shop_data["free_drink"].to_s.include?("あり") ? 1 : 0
+    free_food = shop_data["free_food"].to_s.include?("あり") ? 1 : 0
+    private_room = shop_data["private_room"].to_s.include?("あり") ? 1 : 0
+    course = shop_data["course"].to_s.include?("あり") ? 1 : 0
+    midnight = shop_data["midnight"].to_s.include?("営業している") ? 1 : 0
+    non_smoking = shop_data["non_smoking"].to_s.include?("ない") ? 1 : 0
+
+    # 条件にあうデータがfiltersテーブルにあったらfilterに格納、なかったら作成
+    @filter = Filter.find_or_create_by!(
+      free_drink: free_drink,
+      free_food: free_food,
+      private_room: private_room,
+      course: course,
+      midnight: midnight,
+      non_smoking: non_smoking
+    )
+    # KeywordsとFiltersの組み合わせが存在しなかったら作成
+    KeywordFilter.find_or_create_by!(keyword_id: keyword.id, filter_id: @filter.id)
+    # ShopsとFiltersの組み合わせが存在しなかったら作成
+    ShopFilter.find_or_create_by!(shop_id: shop.id, filter_id: @filter.id)
+    # ShopsとKeywordsの組み合わせが存在しなかったら作成
     ShopKeyword.find_or_create_by!(shop_id: shop.id, keyword_id: keyword.id)
     end
   end

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -1,0 +1,8 @@
+class Filter < ApplicationRecord
+  has_many :keyword_filters
+  has_many :keyword, through: :keyword_filters, dependent: :destroy
+  has_many :shop_filters
+  has_many :shops, through: :shop_filters, dependent: :destroy
+
+  validates :free_drink, uniqueness: { scope: [ :free_food, :private_room, :course, :midnight, :non_smoking ] }
+end

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -1,8 +1,7 @@
 class Filter < ApplicationRecord
   has_many :keyword_filters
   has_many :keyword, through: :keyword_filters, dependent: :destroy
-  has_many :shop_filters
-  has_many :shops, through: :shop_filters, dependent: :destroy
+  has_many :shops
 
   validates :free_drink, uniqueness: { scope: [ :free_food, :private_room, :course, :midnight, :non_smoking ] }
 end

--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -1,6 +1,8 @@
 class Keyword < ApplicationRecord
+  has_many :keyword_filters
+  has_many :filters, through: :keyword_filters, dependent: :destroy
   has_many :shop_keywords
-  has_many :shops, through: :shop_keywords
+  has_many :shops, through: :shop_keywords, dependent: :destroy
 
   validates :word, uniqueness: true
 end

--- a/app/models/keyword_filter.rb
+++ b/app/models/keyword_filter.rb
@@ -1,0 +1,4 @@
+class KeywordFilter < ApplicationRecord
+  belongs_to :keyword
+  belongs_to :filter
+end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -1,7 +1,9 @@
 class Shop < ApplicationRecord
   has_many :bookmarks
+  has_many :shop_filters
+  has_many :filters, through: :shop_filters, dependent: :destroy
   has_many :shop_keywords
-  has_many :keywords, through: :shop_keywords
+  has_many :keywords, through: :shop_keywords, dependent: :destroy
 
   validates :name, presence: true
   validates :unique_number, uniqueness: true

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -1,9 +1,8 @@
 class Shop < ApplicationRecord
   has_many :bookmarks
-  has_many :shop_filters
-  has_many :filters, through: :shop_filters, dependent: :destroy
   has_many :shop_keywords
   has_many :keywords, through: :shop_keywords, dependent: :destroy
+  belongs_to :filter
 
   validates :name, presence: true
   validates :unique_number, uniqueness: true

--- a/app/models/shop_filter.rb
+++ b/app/models/shop_filter.rb
@@ -1,0 +1,4 @@
+class ShopFilter < ApplicationRecord
+  belongs_to :shop
+  belongs_to :filter
+end

--- a/app/models/shop_filter.rb
+++ b/app/models/shop_filter.rb
@@ -1,4 +1,0 @@
-class ShopFilter < ApplicationRecord
-  belongs_to :shop
-  belongs_to :filter
-end

--- a/app/models/shop_keyword.rb
+++ b/app/models/shop_keyword.rb
@@ -1,6 +1,4 @@
 class ShopKeyword < ApplicationRecord
   belongs_to :shop
   belongs_to :keyword
-
-  validates :shop_id, uniqueness: { scope: :keyword_id } # shop_idとkeyword_idの組み合わせの重複拒否
 end

--- a/app/services/hotpepper_api.rb
+++ b/app/services/hotpepper_api.rb
@@ -5,16 +5,22 @@ require "uri"
 class HotpepperApi
   BASE_URL = "https://webservice.recruit.co.jp/hotpepper/gourmet/v1/"
 
-  def self.search_shops(keyword:, start:)
-    binding.pry
+  def self.search_shops(keyword:, start:, free_drink:, free_food:, private_room:, course:, midnight:, non_smoking:)
     uri = URI(BASE_URL)
     params = {
       key: ENV["HOTPEPPER_API_KEY"],
       keyword:, # 検索に使うキーワード
       format: "json", # 受け取るデータの形式
       start: start,
+      free_drink: free_drink.to_i,
+      free_food: free_food.to_i,
+      private_room: private_room.to_i,
+      course: course.to_i,
+      midnight: midnight.to_i,
+      non_smoking: non_smoking.to_i,
       count: count = 100
     }
+    binding.pry
     uri.query = URI.encode_www_form(params)
 
     response = Net::HTTP.get_response(uri) # APIにリクエストを送信

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -39,7 +39,7 @@
         <div class="card card-size">
           <div class="card-body text-center">
             <i class="fa-brands fa-searchengin fa-4x mb-3 " style="color:blue;" ></i>
-            <p class="mb-3"><%= link_to t('.search'), shops_path %></p>
+            <p class="mb-3"><%= link_to t('.search'), shops_path(start: 1) %></p>
             <p class="mb-3">居酒屋を検索することができるよ</p>
           </div>
         </div>

--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -3,17 +3,17 @@
   <%= form_with url: shops_path, method: :get do |f| %>
     <div class="filter">
       <strong><%= t('.filter')%></strong><br>
-      <%= f.check_box :free_drink, { include_hidden: false }, "あり" %>
+      <%= f.check_box :free_drink,{}, "1", "0" %>
       <%= f.label :free_drink, "飲み放題あり" %>
-      <%= f.check_box :free_food,{ include_hidden: false }, "あり" %>
+      <%= f.check_box :free_food, {}, "1" , "0" %>
       <%= f.label :free_food, "食べ放題あり" %>
-      <%= f.check_box :private_room, { include_hidden: false }, "あり" %>
+      <%= f.check_box :private_room, {}, "1", "0" %>
       <%= f.label :private_room, "個室あり" %>
-      <%= f.check_box :course, { include_hidden: false }, "あり" %>
+      <%= f.check_box :course, {}, "1", "0" %>
       <%= f.label :course, "コースあり" %>
-      <%= f.check_box :midnight, { include_hidden: false }, "営業している" %>
+      <%= f.check_box :midnight, {}, "1", "0" %>
       <%= f.label :midnight, "23時以降も営業" %><br>
-      <%= f.check_box :non_smoking, { include_hidden: false }, "なし"%>
+      <%= f.check_box :non_smoking, {}, "1", "0" %>
       <%= f.label :non_smoking, "禁煙" %>
       <%= f.check_box :wine %>
       <%= f.label :wine, "ワイン充実" %>
@@ -26,7 +26,8 @@
     </div>
     <div class="search">
     <%= f.text_field :keyword, placeholder: "検索キーワード" %>
-    <%= button_to t('.search') %>
+    <%= f.hidden_field :start, value: 1 %>
+    <%= f.submit t('.search') %>
   <% end %>
 
   <div class="card-style">
@@ -50,7 +51,7 @@
         <%= paginate @shops %>
       </div>
       <% if @shops.last_page? %>
-        <%= link_to t('.next'),shops_path(start: @shops.current_page, keyword: @keyword.word, page: @shops.current_page)%>
+        <%= link_to t('.next'),shops_path(start: @shops.current_page.to_i * 10 + 1, keyword: @keyword.word, page: @shops.current_page)%>
       <% end %>
     </div>
   </div>

--- a/db/migrate/20250219061829_create_filters.rb
+++ b/db/migrate/20250219061829_create_filters.rb
@@ -1,0 +1,16 @@
+class CreateFilters < ActiveRecord::Migration[8.0]
+  def change
+    create_table :filters do |t|
+      t.string :free_drink
+      t.string :free_food
+      t.string :private_room
+      t.string :course
+      t.string :midnight
+      t.string :non_smoking
+      t.references :keyword, null: false, foreign_key: { on_update: :cascade, on_delete: :cascade }
+      t.references :shop, null: false, foreign_key: { on_update: :cascade, on_delete: :cascade }, type: :integer
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250219062538_shop_keywords.rb
+++ b/db/migrate/20250219062538_shop_keywords.rb
@@ -1,0 +1,5 @@
+class ShopKeywords < ActiveRecord::Migration[8.0]
+  def change
+    drop_table :shop_keywords
+  end
+end

--- a/db/migrate/20250219062928_removeshop_id_from_filters.rb
+++ b/db/migrate/20250219062928_removeshop_id_from_filters.rb
@@ -1,0 +1,6 @@
+class RemoveshopIdFromFilters < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :filters, :shop_id, :integer
+    remove_column :filters, :keyword_id, :bigint
+  end
+end

--- a/db/migrate/20250219063633_create_keyword_filters.rb
+++ b/db/migrate/20250219063633_create_keyword_filters.rb
@@ -1,0 +1,9 @@
+class CreateKeywordFilters < ActiveRecord::Migration[8.0]
+  def change
+    create_table :keyword_filters do |t|
+      t.references :keyword, null: false, foreign_key: { on_update: :cascade, on_dalete: :cascade }
+      t.references :filter, null: false, foreign_key: { on_update: :cascade, on_dalete: :cascade }
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250219063648_create_shop_filters.rb
+++ b/db/migrate/20250219063648_create_shop_filters.rb
@@ -1,9 +1,0 @@
-class CreateShopFilters < ActiveRecord::Migration[8.0]
-  def change
-    create_table :shop_filters do |t|
-      t.references :shop, null: false, foreign_key: { on_update: :cascade, on_dalete: :cascade }, type: :integer
-      t.references :filter, null: false, foreign_key: { on_update: :cascade, on_dalete: :cascade }
-      t.timestamps
-    end
-  end
-end

--- a/db/migrate/20250219063648_create_shop_filters.rb
+++ b/db/migrate/20250219063648_create_shop_filters.rb
@@ -1,0 +1,9 @@
+class CreateShopFilters < ActiveRecord::Migration[8.0]
+  def change
+    create_table :shop_filters do |t|
+      t.references :shop, null: false, foreign_key: { on_update: :cascade, on_dalete: :cascade }, type: :integer
+      t.references :filter, null: false, foreign_key: { on_update: :cascade, on_dalete: :cascade }
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250219065911_change_datatype_free_drink_of_filters.rb
+++ b/db/migrate/20250219065911_change_datatype_free_drink_of_filters.rb
@@ -1,0 +1,10 @@
+class ChangeDatatypeFreeDrinkOfFilters < ActiveRecord::Migration[8.0]
+  def change
+    change_column :filters, :free_drink, :integer
+    change_column :filters, :free_food, :integer
+    change_column :filters, :private_room, :integer
+    change_column :filters, :course, :integer
+    change_column :filters, :midnight, :integer
+    change_column :filters, :non_smoking, :integer
+  end
+end

--- a/db/migrate/20250220020110_create_shop_keywords.rb
+++ b/db/migrate/20250220020110_create_shop_keywords.rb
@@ -1,8 +1,8 @@
 class CreateShopKeywords < ActiveRecord::Migration[8.0]
   def change
     create_table :shop_keywords do |t|
-      t.references :keyword, null: false, foreign_key: { on_update: :cascade, on_delete: :cascade }
       t.references :shop, null: false, foreign_key: { on_update: :cascade, on_delete: :cascade }, type: :integer
+      t.references :keyword, null: false, foreign_key: { on_update: :cascade, on_delete: :cascade }
       t.timestamps
     end
   end

--- a/db/migrate/20250220022741_remove_free_drink_to_shops.rb
+++ b/db/migrate/20250220022741_remove_free_drink_to_shops.rb
@@ -1,0 +1,14 @@
+class RemoveFreeDrinkToShops < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :shops, :free_drink, :string
+    remove_column :shops, :free_food, :string
+    remove_column :shops, :private_room, :string
+    remove_column :shops, :course, :string
+    remove_column :shops, :midnight, :string
+    remove_column :shops, :non_smoking, :string
+    remove_column :shops, :sake, :integer
+    remove_column :shops, :wine, :integer
+    remove_column :shops, :shochu, :integer
+    remove_column :shops, :cocktail, :integer
+  end
+end

--- a/db/migrate/20250220031816_add_unique_index_to_filters.rb
+++ b/db/migrate/20250220031816_add_unique_index_to_filters.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToFilters < ActiveRecord::Migration[8.0]
+  def change
+    add_index :filters, [ :free_drink, :free_food, :private_room, :course, :midnight, :non_smoking ], unique: true
+  end
+end

--- a/db/migrate/20250221032137_shop_filters.rb
+++ b/db/migrate/20250221032137_shop_filters.rb
@@ -1,0 +1,5 @@
+class ShopFilters < ActiveRecord::Migration[8.0]
+  def change
+    drop_table :shop_filters
+  end
+end

--- a/db/migrate/20250221032517_add_filter_id_to_shops.rb
+++ b/db/migrate/20250221032517_add_filter_id_to_shops.rb
@@ -1,0 +1,5 @@
+class AddFilterIdToShops < ActiveRecord::Migration[8.0]
+  def change
+    add_column :shops, :filter_id, :bigint
+  end
+end

--- a/db/migrate/20250221033632_add_foreign_key_to_shops.rb
+++ b/db/migrate/20250221033632_add_foreign_key_to_shops.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyToShops < ActiveRecord::Migration[8.0]
+  def change
+    add_foreign_key :shops, :filters, column: :filter_id, on_update: :cascade, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_16_033141) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_20_031816) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -48,15 +48,45 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_16_033141) do
     t.index ["user_id"], name: "fk_rails_c1ff6fa4ac"
   end
 
+  create_table "filters", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "free_drink"
+    t.integer "free_food"
+    t.integer "private_room"
+    t.integer "course"
+    t.integer "midnight"
+    t.integer "non_smoking"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["free_drink", "free_food", "private_room", "course", "midnight", "non_smoking"], name: "idx_on_free_drink_free_food_private_room_course_mid_6d361bf595", unique: true
+  end
+
+  create_table "keyword_filters", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "keyword_id", null: false
+    t.bigint "filter_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["filter_id"], name: "index_keyword_filters_on_filter_id"
+    t.index ["keyword_id"], name: "index_keyword_filters_on_keyword_id"
+  end
+
   create_table "keywords", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "word"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "shop_keywords", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "keyword_id", null: false
+  create_table "shop_filters", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "shop_id", null: false
+    t.bigint "filter_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["filter_id"], name: "index_shop_filters_on_filter_id"
+    t.index ["shop_id"], name: "index_shop_filters_on_shop_id"
+  end
+
+  create_table "shop_keywords", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "shop_id", null: false
+    t.bigint "keyword_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["keyword_id"], name: "index_shop_keywords_on_keyword_id"
@@ -78,16 +108,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_16_033141) do
     t.string "unique_number"
     t.text "logo_image"
     t.json "image"
-    t.string "free_drink"
-    t.string "free_food"
-    t.string "private_room"
-    t.string "course"
-    t.string "midnight"
-    t.string "non_smoking"
-    t.integer "wine"
-    t.integer "sake"
-    t.integer "cocktail"
-    t.integer "shochu"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -107,6 +127,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_16_033141) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "bookmarks", "shops"
   add_foreign_key "bookmarks", "users"
+  add_foreign_key "keyword_filters", "filters", on_update: :cascade
+  add_foreign_key "keyword_filters", "keywords", on_update: :cascade
+  add_foreign_key "shop_filters", "filters", on_update: :cascade
+  add_foreign_key "shop_filters", "shops", on_update: :cascade
   add_foreign_key "shop_keywords", "keywords", on_update: :cascade, on_delete: :cascade
   add_foreign_key "shop_keywords", "shops", on_update: :cascade, on_delete: :cascade
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_20_031816) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_21_033632) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -75,15 +75,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_20_031816) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "shop_filters", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "shop_id", null: false
-    t.bigint "filter_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["filter_id"], name: "index_shop_filters_on_filter_id"
-    t.index ["shop_id"], name: "index_shop_filters_on_shop_id"
-  end
-
   create_table "shop_keywords", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "shop_id", null: false
     t.bigint "keyword_id", null: false
@@ -108,6 +99,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_20_031816) do
     t.string "unique_number"
     t.text "logo_image"
     t.json "image"
+    t.bigint "filter_id"
+    t.index ["filter_id"], name: "fk_rails_2a05a1f881"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -129,8 +122,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_20_031816) do
   add_foreign_key "bookmarks", "users"
   add_foreign_key "keyword_filters", "filters", on_update: :cascade
   add_foreign_key "keyword_filters", "keywords", on_update: :cascade
-  add_foreign_key "shop_filters", "filters", on_update: :cascade
-  add_foreign_key "shop_filters", "shops", on_update: :cascade
   add_foreign_key "shop_keywords", "keywords", on_update: :cascade, on_delete: :cascade
   add_foreign_key "shop_keywords", "shops", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "shops", "filters", on_update: :cascade, on_delete: :cascade
 end

--- a/test/models/shop_keyword_test.rb
+++ b/test/models/shop_keyword_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ShopKeywordTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
以下の機能を実現する仕組みを実装しました
**APIにリクエストの送信を行う条件**
・検索に使用されたキーワードと絞り込み条件の組み合わせが初の場合
・「次の100件」リンクがクリックされた時
**データベース内検索を行う条件**
・検索に使用されたキーワードと絞り込み条件の組み合わせが二回目の場合

---
## 修正内容
### 1. テーブルスキーマの変更
データベースのスキーマを以下のように修正しました
<img width="571" alt="スクリーンショット 2025-02-21 14 22 18" src="https://github.com/user-attachments/assets/ed245495-54fb-4e7b-bf33-055ad1e2d770" />

### 2. APIリクエストとデータベース検索の条件分岐
  - params[:start]の値とkeyword_filterの有無で分岐
    - params[:start] : APIリクエスト時に検索結果の何件目から取得するのかを指定する値
    以下のように設定しています
      1. /homes から検索ページにアクセスする際(params[:start] = 1)
      2. 「次の100件」リンクをクリックした際(params[:start] = current_page.to_i * 100 + 1)
      3. ページ遷移を行なった際(params[:start] = nil)
      ※params[:start].to_i実施するためnilの場合は0に置き換わる
      
    - keyword_filter: 入力されたキーワードと絞り込み条件の組み合わせを検索し、ヒットすればkeywordFiltersのデータを格納する

### 3. APIにリクエストを送る際の手順
1. search_paramsを用いてAPIにリクエストを送信
2. shops_createメソッドを呼び出し、APIから取得した各店舗情報をデータベースに保存
  - 以下のデータ項目を文字列から 0 or 1 に修正
    - free_drink
    - free_food
    - private_room
    - course
    - midnight
    - non_smoking
  - 上記の組み合わせをFiltersテーブル内で検索し、ヒットすればfilterに格納し、なければ作成後格納
  - Shopsテーブル内をunique_numberで検索し、ヒットしたらupdate!、しなかったらcreate!を行う
  ※この時Shopsテーブルにfilter_idも保存する
3. データベース検索の手順
  - 検索結果を@shopsに格納し、ビューに渡す

### 4 データベース内で検索を行いデータを取得
  データベース内に対して絞り込み条件を用いた検索、検索結果を@shopsに格納しビューに渡す

---
## 確認方法
1. 新しいキーワードor絞り込み条件で検索ボタンを押すと、検索結果が表示されることを確認
2. ページ切り替えを行うとページ番号に応じて検索結果が表示されることを確認
3. 最終ページに遷移すると下部に「次の100件」リンクが表示され、クリックすると次の100件が表示され、件数に伴いページ数も増えることを確認



    
