### PR TITLE
詳細ページの修正

### DIFF
--- a/app/assets/stylesheets/shops/show.css
+++ b/app/assets/stylesheets/shops/show.css
@@ -1,4 +1,4 @@
-.shops-detail {
+.shops-show {
 
 .title {
   text-align: center;
@@ -13,7 +13,7 @@
   margin-bottom: 20px;
 }
 
-.shop-detail {
+.shops-detail {
   display: flex;
   border: 1px solid #ddd;
   align-items: center;
@@ -46,4 +46,5 @@
   margin-bottom: 40px;
   margin-top: 10px;
 }
+
 }

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -47,6 +47,10 @@ class ShopsController < ApplicationController
     @final_page = @current_page < 5 ? 7 : [ @current_page + 3, @total_page ].min
   end
 
+  def show
+    @shop = Shop.find(params[:id])
+  end
+
   private
 
   def search_params

--- a/app/views/shops/_shop.html.erb
+++ b/app/views/shops/_shop.html.erb
@@ -2,11 +2,11 @@
   <% @shops.each do |shop| %>
     <div class="container">
       <div class="image">
-        <%= image_tag shop["logo_image"], class:"image"%>
+        <%= image_tag shop.logo_image, class:"image"%>
       </div>
       <div class="shops">
-        <p class="shops-name"><%=link_to shop["name"], shops_detail_path(shop)%> <%#店舗名%></p>
-        <p><%= shop["address"]%> <%#住所%></p>
+        <p class="shops-name"><%=link_to shop.name , shop_path(shop), data: { turbo_frame: "_top" }%> <%#店舗名%></p>
+        <p><%= shop.address%> <%#住所%></p>
         <p>¥<%= shop["budget"]["name"]%> <%#平均予算%></p>
       </div>
       <div class="icon">

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -1,0 +1,75 @@
+<div class="shops-show">  
+  <div class="card-style">
+    <p class="title"><strong><%= @shop.name %></strong></p>
+    <div class="image">
+      <%= image_tag @shop.image["pc"]["l"] %>
+    </div>
+    <div class="shops-detail">
+      <div class="label">
+        <%= t('.address') %>
+      </div>
+      <div class="data">
+        <%= @shop.address %>
+      </div>
+    </div>
+    <div class="shops-detail">
+      <div class="label">
+        <%= t('.phone_number') %>
+      </div>
+      <div class="data">
+        <%= @shop.phone_number %>
+      </div>
+    </div>
+    <div class="shops-detail">
+      <div class="label">
+      <%= t('.access') %>
+      </div>
+      <div class="data">
+        <%= @shop.access %>
+      </div>
+    </div>
+    <div class="shops-detail">
+      <div class="label">
+        <%= t('.opening_hours') %>
+      </div>
+      <div class="data">
+        <%= @shop.opening_hours %>
+      </div>
+    </div>
+    <div class="shops-detail">
+      <div class="label">
+        <%= t('.closing_day') %>
+      </div>
+      <div class="data">
+        <%= @shop.closing_day %>
+      </div>
+    </div>
+    <div class="shops-detail">
+      <div class="label">
+        <%= t('.budget') %>
+      </div>
+      <div class="data">
+        ¥<%= @shop.budget["average"] %>
+      </div>
+    </div>
+    <div class="shops-detail">
+      <div class="label">
+        <%= t('.number_of_seats') %>
+      </div>
+      <div class="data">
+        <%= @shop.number_of_seats %>席
+      </div>
+    </div>
+    <div class="shops-detail">
+      <div class="label">
+        <%= t('.url') %>
+      </div>
+      <div class="data">
+        <%=link_to @shop.url["pc"], @shop.url["pc"] %>
+      </div>
+    </div>
+  </div>
+  <div class="back-link">
+    <%= link_to t('.back'), shops_path %>
+  </div>
+</div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -40,7 +40,7 @@ ja:
       search: 検索
       title: 検索フォーム
       filter: 検索条件
-    detail:
+    show:
       title: 店舗詳細ページ
       name_of_shop: 店名
       address: 住所

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
   get "homes", to: "homes#index"
   get "shops", to: "shops#index"
-  get "shops/detail", to: "shops#detail"
+  get "shops/:id", to: "shops#show", as: "shop"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
### 概要
検索フォームで表示された店舗情報の一覧から、各店舗の詳細情報ページに遷移することができるように修正しました
レイアウトは前回作成した時と同じです
<img width="1334" alt="スクリーンショット 2025-02-24 17 31 11" src="https://github.com/user-attachments/assets/938170c5-9dbf-470d-ac73-591deeaa3df2" />

<img width="1331" alt="スクリーンショット 2025-02-24 17 31 39" src="https://github.com/user-attachments/assets/b04f53f7-e5ad-4635-aafe-ff3dd8886cbe" />



---
### 修正内容
1. 'shops'コントローラに#showアクションの作成

2. 検索フォームで表示された店舗情報の各店舗名に詳細ページへのリンクを作成

### 確認内容
1. 各店舗の詳細ページへの遷移
  店舗名のリンクをクリックすると各店舗の詳細ページへ遷移することを確認