### PR TITLE
店舗一覧におけるお気に入り登録機能の実装

### DIFF
--- a/app/assets/stylesheets/shops/index.css
+++ b/app/assets/stylesheets/shops/index.css
@@ -55,8 +55,8 @@
 }
 
 .icon {
-  margin-left: 20px;
-  color:pink;
+  margin-left: 40px;
+  color: pink;
 }
 
 .pagination {

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,0 +1,22 @@
+class BookmarksController < ApplicationController
+  def create
+    bookmark = Bookmark.new(bookmark_params)
+    if bookmark.save
+      flash[:notice] = "お気に入り登録しました"
+      redirect_to shops_path
+    end
+  end
+
+  def destroy
+    bookmark = Bookmark.find(params[:id])
+    bookmark.destroy
+    flash[:alert] = "お気に入りを解除しました"
+    redirect_to shops_path
+  end
+
+  private
+
+  def bookmark_params
+    params.permit(:shop_id, :user_id)
+  end
+end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,4 +1,6 @@
 class Bookmark < ApplicationRecord
   belongs_to :user
   belongs_to :shop
+
+  validates :user_id, uniqueness: { scope: [ :shop_id ] }
 end

--- a/app/views/shops/_shop.html.erb
+++ b/app/views/shops/_shop.html.erb
@@ -9,9 +9,19 @@
         <p><%= shop.address%> <%#住所%></p>
         <p>¥<%= shop["budget"]["name"]%> <%#平均予算%></p>
       </div>
-      <div class="icon">
-      <i class="fa-solid fa-heart fa-3x icon"></i>
-      </div>
+      <% if bookmark = Bookmark.find_by(shop_id: shop.id, user_id: current_user.id) %>
+        <%= link_to bookmark_path(bookmark), data: { turbo_method: :delete } do %>
+          <div class="icon">
+            <i class="fa-solid fa-heart fa-3x"></i>
+          </div>
+        <% end %>
+      <% else %>
+        <%= link_to bookmarks_path(shop_id: shop.id, user_id: current_user.id), data: { turbo_method: :post } do %>
+          <div class="icon">
+            <i class="fa-regular fa-heart fa-3x"></i>
+          </div>
+        <% end %>
+      <% end %>
     </div>
   <% end %>
   <div class="pagination">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
   get "homes", to: "homes#index"
   get "shops", to: "shops#index"
   get "shops/:id", to: "shops#show", as: "shop"
+
+  resources :bookmarks
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
### 概要
ユーザーが各店舗情報に対してお気に入り登録ができる機能を実装しました
以下のようにお気に入り登録時と未登録時が一目でわかるようにしました
🩷→登録済み
♡→未登録
<img width="939" alt="スクリーンショット 2025-02-28 17 19 29" src="https://github.com/user-attachments/assets/fcc5047c-8434-40ce-a1c5-fe527fba79d3" />

---
### 修正内容
1. bookmarksコントローラに以下のアクションを実装
  - create: お気に入り登録処理を実行
  - destroy: お気に入り解除処理を実行

2. shop/index.html.erbにおけるハート表示の切り替え
  - お気に入り未登録の場合: createアクションへのリンクを表示(♡)
  - すでにお気に入り登録済みの場合: destroyアクションへのリンクを表示(❤️)

---
### 確認方法
1. お気に入り登録処理
 - 店舗情報の横に♡が表示され、クリックすると♡→❤️に切り替わり、"お気に入り登録しました"とメッセージが表示される

2. お気に入り解除処理
 - 店舗情報の横に❤️が表示され、クリックすると❤️ →♡に切り替わり、"お気に入りを解除しました"とメッセージが表示される