### PR TITLE
詳細ページからもお気に入り登録ができるように修正

### DIFF
--- a/app/assets/stylesheets/shops/show.css
+++ b/app/assets/stylesheets/shops/show.css
@@ -3,9 +3,21 @@
 .title {
   text-align: center;
   margin-top: 10px;
+  margin-left: 50px;
   font-size: 45px;
-  border-bottom: 1px solid #ccc;
   padding: 10px;
+}
+
+.container {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid #ccc;
+  margin-bottom: 30px;
+}
+
+.icon {
+  margin-left: 40px;
+  color: pink;
 }
 
 .image {

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -3,7 +3,7 @@ class BookmarksController < ApplicationController
     bookmark = Bookmark.new(bookmark_params)
     if bookmark.save
       flash[:notice] = "お気に入り登録しました"
-      redirect_to shops_path
+      redirect_back fallback_location: shops_path
     end
   end
 
@@ -11,7 +11,7 @@ class BookmarksController < ApplicationController
     bookmark = Bookmark.find(params[:id])
     bookmark.destroy
     flash[:alert] = "お気に入りを解除しました"
-    redirect_to shops_path
+    redirect_back fallback_location: shops_path
   end
 
   private

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -1,6 +1,23 @@
 <div class="shops-show">  
   <div class="card-style">
-    <p class="title"><strong><%= @shop.name %></strong></p>
+    <div class="container">
+      <div class="title">
+        <strong><%= @shop.name %></strong>
+      </div>
+      <% if bookmark = Bookmark.find_by(shop_id: @shop.id, user_id: current_user.id) %>
+          <%= link_to bookmark_path(bookmark), data: { turbo_method: :delete } do %>
+            <div class="icon">
+              <i class="fa-solid fa-heart fa-3x"></i>
+            </div>
+          <% end %>
+        <% else %>
+          <%= link_to bookmarks_path(shop_id: @shop.id, user_id: current_user.id), data: { turbo_method: :post } do %>
+            <div class="icon">
+              <i class="fa-regular fa-heart fa-3x"></i>
+            </div>
+          <% end %>
+        <% end %>
+    </div>
     <div class="image">
       <%= image_tag @shop.image %>
     </div>


### PR DESCRIPTION
### 概要
店舗一覧画面からだけでなく店舗詳細画面からもお気に入り登録/解除ができるように変更しました
またredirect_backを用いることでお気に入り登録/解除を行った直前の画面に遷移するように変更しました

店舗一覧→お気に入り登録/解除→店舗一覧へリダイレクト
店舗詳細→お気に入り登録/解除→店舗詳細へリダイレクト

---