### PR TITLE
お気に入り一覧ページの作成

### DIFF
--- a/app/assets/stylesheets/bookmarks/index.css
+++ b/app/assets/stylesheets/bookmarks/index.css
@@ -1,0 +1,61 @@
+.bookmarks-index {
+
+.title {
+  margin-top: 50px;
+  text-align: center;
+}
+
+.card-style {
+  margin: 0 auto;
+  width: 800px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  box-shadow: 0 4px 9px rgba(0,0,0,0.1);
+  margin-top: 40px;
+  padding: 16px;
+  margin-bottom: 50px;
+}
+
+.container {
+  border: 1px solid #ddd;
+  box-shadow: 0 4px 9px rgba(0,0,0,0.1);
+  margin-bottom: 40px;
+  display: flex;
+  align-items: center;
+}
+
+.filter {
+  margin-left: 30em;
+  margin: 0 auto;
+  width: 650px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  box-shadow: 0 4px 9px rgba(0,0,0,0.1);
+  margin-top: 20px;
+  padding: 13px;
+  margin-bottom: 20px;
+}
+
+.search {
+  text-align: center;
+}
+.shops {
+  width: 400px;
+  overflow-wrap: break-word;
+}
+
+.shops-name {
+  font-size: 20px;
+}
+
+.image {
+  width: 130px;
+  height: 130px;
+  margin-right: 100px;
+}
+
+.icon {
+  margin-left: 40px;
+  color: pink;
+}
+}

--- a/app/assets/stylesheets/bookmarks/index.css
+++ b/app/assets/stylesheets/bookmarks/index.css
@@ -58,4 +58,36 @@
   margin-left: 40px;
   color: pink;
 }
+
+.pagination {
+ display: flex;
+ justify-content: space-between;
+ font-size: 15px;
+ margin: 20px;
+ 
+}
+.page {
+ margin: 0 auto;
+}
+
+.current_page {
+ padding-top: 4px;
+ font-weight: bold;
+ color: white;
+ background: #007bff;
+ width: 35px;
+ height: 35px;
+}
+.page_link{
+ padding-top: 4px;
+ color: blue;
+ background: #FFF;
+ border: 1px solid #ddd;
+ width: 35px;
+ height: 35px;
+}
+
+.no-underline {
+ text-decoration: none;
+}
 }

--- a/app/assets/stylesheets/bookmarks/index.css
+++ b/app/assets/stylesheets/bookmarks/index.css
@@ -60,34 +60,38 @@
 }
 
 .pagination {
- display: flex;
- justify-content: space-between;
- font-size: 15px;
- margin: 20px;
+  display: flex;
+  justify-content: space-between;
+  font-size: 15px;
+  margin: 20px;
  
 }
 .page {
- margin: 0 auto;
+  margin: 0 auto;
 }
 
 .current_page {
- padding-top: 4px;
- font-weight: bold;
- color: white;
- background: #007bff;
- width: 35px;
- height: 35px;
+  padding-top: 4px;
+  font-weight: bold;
+  color: white;
+  background: #007bff;
+  width: 35px;
+  height: 35px;
 }
 .page_link{
- padding-top: 4px;
- color: blue;
- background: #FFF;
- border: 1px solid #ddd;
- width: 35px;
- height: 35px;
+  padding-top: 4px;
+  color: blue;
+  background: #FFF;
+  border: 1px solid #ddd;
+  width: 35px;
+  height: 35px;
 }
 
 .no-underline {
- text-decoration: none;
+  text-decoration: none;
+}
+
+.bookmark-nil {
+  margin-top: 200px;
 }
 }

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,4 +1,7 @@
 class BookmarksController < ApplicationController
+  def index
+    @shops = Shop.joins(:bookmarks).where(bookmarks: { user_id: current_user.id })
+  end
   def create
     bookmark = Bookmark.new(bookmark_params)
     if bookmark.save

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,6 +1,16 @@
 class BookmarksController < ApplicationController
   def index
-    @shops = Shop.joins(:bookmarks).where(bookmarks: { user_id: current_user.id })
+    @bookmark_shops = Shop.joins(:bookmarks).where(bookmarks: { user_id: current_user.id })
+    @current_page = (params[:page].to_i > 0) ? params[:page].to_i : 1
+    @total_shops = @bookmark_shops.count
+    @total_page = (@total_shops.to_f / Shop::PAGE_NUMBER).ceil
+    @bookmark_shops = @bookmark_shops.offset((@current_page - 1)* Shop::PAGE_NUMBER).limit(Shop::PAGE_NUMBER)
+    @previous_page = @current_page > 1 ? @current_page - 1 : nil
+    @next_page = @total_page > @current_page ? @current_page + 1 : nil
+    @first_page = @current_page > 1 ? 1 : nil
+    @last_page = @total_page > 1 ? @total_page : nil
+    @start_page = [ @current_page - 3, 1 ].max
+    @final_page = [ @current_page + 3, @total_page ].min
   end
   def create
     bookmark = Bookmark.new(bookmark_params)

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -3,24 +3,24 @@
     <h1><strong>お気に入り一覧</strong></h1>
    <div>
   <div class="card-style">
-    <% @shops.each do |shop| %>
+    <% @bookmark_shops.each do |bookmark| %>
       <div class="container">
         <div class="image">
-          <%= image_tag shop.logo_image, class:"image"%>
+          <%= image_tag bookmark.logo_image, class:"image"%>
         </div>
         <div class="shops">
-          <p class="shops-name"><%=link_to shop.name , shop_path(shop), data: { turbo_frame: "_top" }%> <%#店舗名%></p>
-          <p><%= shop.address%> <%#住所%></p>
-          <p>¥<%= shop[:budget]%> <%#平均予算%></p>
+          <p class="shops-name"><%=link_to bookmark.name , shop_path(bookmark), data: { turbo_frame: "_top" }%> <%#店舗名%></p>
+          <p><%= bookmark.address%> <%#住所%></p>
+          <p>¥<%= bookmark[:budget]%> <%#平均予算%></p>
         </div>
-        <% if bookmark = Bookmark.find_by(shop_id: shop.id, user_id: current_user.id) %>
+        <% if bookmark = Bookmark.find_by(shop_id: bookmark.id, user_id: current_user.id) %>
           <%= link_to bookmark_path(bookmark), data: { turbo_method: :delete } do %>
             <div class="icon">
               <i class="fa-solid fa-heart fa-3x"></i>
             </div>
           <% end %>
         <% else %>
-          <%= link_to bookmarks_path(shop_id: shop.id, user_id: current_user.id), data: { turbo_method: :post } do %>
+          <%= link_to bookmarks_path(shop_id: bookmark.id, user_id: current_user.id), data: { turbo_method: :post } do %>
             <div class="icon">
               <i class="fa-regular fa-heart fa-3x"></i>
             </div>
@@ -28,5 +28,38 @@
         <% end %>
       </div>
     <% end %>
+    <div class="pagination">
+      <% if @first_page %>
+        <div class="page_link">
+          <%= link_to t('.first_page'), bookmarks_path(page: @first_page), data: { turbo_frame: "_top" },class:"no-underline"  %>
+        </div>
+      <% end %>
+      <% if @previous_page%>
+        <div class="page_link">
+          <%= link_to t('.previous'), bookmarks_path(page: @previous_page), data: { turbo_frame: "_top" },class:"no-underline"  %>
+        </div>
+      <% end %>
+      <% (@start_page..@final_page).each do |page| %>
+        <% if page != @current_page %>
+          <div class="page_link">
+            <%= link_to page, bookmarks_path(page: page), data: { turbo_frame: "_top" },class:"no-underline"  %>
+          </div>
+        <% else %>
+          <div class="current_page">
+            <%= @current_page %>
+          </div>
+        <% end %>
+      <% end %>
+      <% if @next_page %>
+        <div class="page_link">
+          <%= link_to t('.next'), bookmarks_path(page: @next_page), data: { turbo_frame: "_top" },class:"no-underline" %>
+        </div>
+      <% end %>
+      <% if @last_page %>
+        <div class="page_link">
+          <%= link_to t('.last_page'), bookmarks_path(page: @last_page), data: { turbo_frame: "_top" },class:"no-underline"  %>
+        </div>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,0 +1,32 @@
+<div class="bookmarks-index">
+  <div class="title">
+    <h1><strong>お気に入り一覧</strong></h1>
+   <div>
+  <div class="card-style">
+    <% @shops.each do |shop| %>
+      <div class="container">
+        <div class="image">
+          <%= image_tag shop.logo_image, class:"image"%>
+        </div>
+        <div class="shops">
+          <p class="shops-name"><%=link_to shop.name , shop_path(shop), data: { turbo_frame: "_top" }%> <%#店舗名%></p>
+          <p><%= shop.address%> <%#住所%></p>
+          <p>¥<%= shop[:budget]%> <%#平均予算%></p>
+        </div>
+        <% if bookmark = Bookmark.find_by(shop_id: shop.id, user_id: current_user.id) %>
+          <%= link_to bookmark_path(bookmark), data: { turbo_method: :delete } do %>
+            <div class="icon">
+              <i class="fa-solid fa-heart fa-3x"></i>
+            </div>
+          <% end %>
+        <% else %>
+          <%= link_to bookmarks_path(shop_id: shop.id, user_id: current_user.id), data: { turbo_method: :post } do %>
+            <div class="icon">
+              <i class="fa-regular fa-heart fa-3x"></i>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -2,64 +2,70 @@
   <div class="title">
     <h1><strong>お気に入り一覧</strong></h1>
    <div>
-  <div class="card-style">
-    <% @bookmark_shops.each do |bookmark| %>
-      <div class="container">
-        <div class="image">
-          <%= image_tag bookmark.logo_image, class:"image"%>
+  <% if @bookmark_shops.present? %>
+    <div class="card-style">
+      <% @bookmark_shops.each do |bookmark| %>
+        <div class="container">
+          <div class="image">
+            <%= image_tag bookmark.logo_image, class:"image"%>
+          </div>
+          <div class="shops">
+            <p class="shops-name"><%=link_to bookmark.name , shop_path(bookmark), data: { turbo_frame: "_top" }%> <%#店舗名%></p>
+            <p><%= bookmark.address%> <%#住所%></p>
+            <p>¥<%= bookmark[:budget]%> <%#平均予算%></p>
+          </div>
+          <% if bookmark = Bookmark.find_by(shop_id: bookmark.id, user_id: current_user.id) %>
+            <%= link_to bookmark_path(bookmark), data: { turbo_method: :delete } do %>
+              <div class="icon">
+                <i class="fa-solid fa-heart fa-3x"></i>
+              </div>
+            <% end %>
+          <% else %>
+            <%= link_to bookmarks_path(shop_id: bookmark.id, user_id: current_user.id), data: { turbo_method: :post } do %>
+              <div class="icon">
+                <i class="fa-regular fa-heart fa-3x"></i>
+              </div>
+            <% end %>
+          <% end %>
         </div>
-        <div class="shops">
-          <p class="shops-name"><%=link_to bookmark.name , shop_path(bookmark), data: { turbo_frame: "_top" }%> <%#店舗名%></p>
-          <p><%= bookmark.address%> <%#住所%></p>
-          <p>¥<%= bookmark[:budget]%> <%#平均予算%></p>
-        </div>
-        <% if bookmark = Bookmark.find_by(shop_id: bookmark.id, user_id: current_user.id) %>
-          <%= link_to bookmark_path(bookmark), data: { turbo_method: :delete } do %>
-            <div class="icon">
-              <i class="fa-solid fa-heart fa-3x"></i>
+      <% end %>
+      <div class="pagination">
+        <% if @first_page %>
+          <div class="page_link">
+            <%= link_to t('.first_page'), bookmarks_path(page: @first_page), data: { turbo_frame: "_top" },class:"no-underline"  %>
+          </div>
+        <% end %>
+        <% if @previous_page%>
+          <div class="page_link">
+            <%= link_to t('.previous'), bookmarks_path(page: @previous_page), data: { turbo_frame: "_top" },class:"no-underline"  %>
+          </div>
+        <% end %>
+        <% (@start_page..@final_page).each do |page| %>
+          <% if page != @current_page %>
+            <div class="page_link">
+              <%= link_to page, bookmarks_path(page: page), data: { turbo_frame: "_top" },class:"no-underline"  %>
+            </div>
+          <% else %>
+            <div class="current_page">
+              <%= @current_page %>
             </div>
           <% end %>
-        <% else %>
-          <%= link_to bookmarks_path(shop_id: bookmark.id, user_id: current_user.id), data: { turbo_method: :post } do %>
-            <div class="icon">
-              <i class="fa-regular fa-heart fa-3x"></i>
-            </div>
-          <% end %>
+        <% end %>
+        <% if @next_page %>
+          <div class="page_link">
+            <%= link_to t('.next'), bookmarks_path(page: @next_page), data: { turbo_frame: "_top" },class:"no-underline" %>
+          </div>
+        <% end %>
+        <% if @last_page %>
+          <div class="page_link">
+            <%= link_to t('.last_page'), bookmarks_path(page: @last_page), data: { turbo_frame: "_top" },class:"no-underline"  %>
+          </div>
         <% end %>
       </div>
-    <% end %>
-    <div class="pagination">
-      <% if @first_page %>
-        <div class="page_link">
-          <%= link_to t('.first_page'), bookmarks_path(page: @first_page), data: { turbo_frame: "_top" },class:"no-underline"  %>
-        </div>
-      <% end %>
-      <% if @previous_page%>
-        <div class="page_link">
-          <%= link_to t('.previous'), bookmarks_path(page: @previous_page), data: { turbo_frame: "_top" },class:"no-underline"  %>
-        </div>
-      <% end %>
-      <% (@start_page..@final_page).each do |page| %>
-        <% if page != @current_page %>
-          <div class="page_link">
-            <%= link_to page, bookmarks_path(page: page), data: { turbo_frame: "_top" },class:"no-underline"  %>
-          </div>
-        <% else %>
-          <div class="current_page">
-            <%= @current_page %>
-          </div>
-        <% end %>
-      <% end %>
-      <% if @next_page %>
-        <div class="page_link">
-          <%= link_to t('.next'), bookmarks_path(page: @next_page), data: { turbo_frame: "_top" },class:"no-underline" %>
-        </div>
-      <% end %>
-      <% if @last_page %>
-        <div class="page_link">
-          <%= link_to t('.last_page'), bookmarks_path(page: @last_page), data: { turbo_frame: "_top" },class:"no-underline"  %>
-        </div>
-      <% end %>
     </div>
-  </div>
+  <% else %>
+    <div class="bookmark-nil">
+      <strong>お気に入り登録はありません</strong>
+    </div>
+  <% end %>
 </div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -30,7 +30,7 @@
             <div class="text-center mb-3">
             <i class="fa-solid fa-heart fa-4x" style="color:pink;"></i>
             </div>
-            <p class="text-center mb-3"><%= link_to t('.bookmark') %></p>
+            <p class="text-center mb-3"><%= link_to t('.bookmark'), bookmarks_path %></p>
             <p class="bookmark text-center">いいねをつけたお店を確認できるよ</p>
           </div>
         </div>

--- a/app/views/shops/_shop.html.erb
+++ b/app/views/shops/_shop.html.erb
@@ -7,7 +7,7 @@
       <div class="shops">
         <p class="shops-name"><%=link_to shop.name , shop_path(shop), data: { turbo_frame: "_top" }%> <%#店舗名%></p>
         <p><%= shop.address%> <%#住所%></p>
-        <p>¥<%= shop["budget"]["name"]%> <%#平均予算%></p>
+        <p>¥<%= shop[:budget]%> <%#平均予算%></p>
       </div>
       <% if bookmark = Bookmark.find_by(shop_id: shop.id, user_id: current_user.id) %>
         <%= link_to bookmark_path(bookmark), data: { turbo_method: :delete } do %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -58,10 +58,9 @@ ja:
       next100: 次の100件
       first_page: "<<"
       last_page: ">>"
-  views:
-    pagination:
-      first: "<<"
-      last: ">>"
-      previous: "<" 
-      next: ">" 
-      truncate: ...
+  bookmarks:
+    index:
+      next: ">"
+      previous: "<"
+      first_page: "<<"
+      last_page: ">>"


### PR DESCRIPTION
### 概要
ユーザーがお気に入りをつけた店舗の一覧を確認することができるお気に入り一覧ページを作成しました
店舗検索ページ同様にページネーション機能を実装しており、お気に入り登録を行うと店舗情報が追加され、解除すると一覧から削除される仕組みになっております。
またこのページは/homesのお気に入りページリンクから遷移することができます

---
### 修正内容
1. 'bookmarks_controller'の'index'アクションの作成
  - ページネーション処理

2. 'bookmarks_index.html.erb'に一覧表示とページネーションの表示

### 確認方法
1. お気に入りページへのアクセス確認
  -  /homes のお気に入りページリンクをクリックするとお気に入りページへ遷移することを確認

2. お気に入り登録/解除の反映確認
  - お気に入り登録を行うと該当の店舗情報がお気に入り一覧に追加されることを確認
  - お気に入り解除を行うと該当の店舗情報がお気に入り一覧から削除されることを確認

3. ページネーションの確認
  - **1ページ目**
    - 最大7ページ分のページ番号リンクを(1.2.3.4.5.6.7)を表示
    - "<"(次ページ)と"<<"(最終ページ)リンクの表示
  - **最終ページ**
    - 最大7つ前までのページ番号リンクが表示される
    - ">"(前ページ)と">>"(最初のページ)リンクの表示
  - **途中のページ**
    - 現在のページの前後合計6ページのページ番号リンクを表示
    - "<"(次ページ)と"<<"(最終ページ)リンクの表示
    - ">"(前ページ)と">>"(最初のページ)リンクの表示

  - **ページを進める処理**
    -  ">" をクリックすると一つ次のページへ遷移し、">>"をクリックすると最後のページに遷移することを確認
    - 「次の100件」リンクをクリックすると次のページへ遷移し、さらに+ 最大10ページが追加される

  - **ページを戻る処理**
    - "<"をクリックすると一つ前のページへ遷移し、"<<"をクリックすると最初のページに遷移することを確認