### PR TITLE
paginationの引数の修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,8 +21,11 @@ class ApplicationController < ActionController::Base
   PAGE_NUMBER = 10
   DISPLAY_PAGE_RANGE = 3
 
-  def pagination(shops, current_location_search, shop_ids, current_latitude, current_longitude)
-    @keyword_filter_params = @filter_conditions.merge(keyword: @keyword.word, current_location: current_location_search, shop_ids: shop_ids, latitude: current_latitude, longitude: current_longitude)
+  def pagination(shops:, current_location_search: nil, shop_ids: nil, current_latitude: nil, current_longitude: nil)
+    # @keywordがtrue→shopsコントローラからの処理 false→bookmarksコントローラからの処理
+    if @keyword
+      @keyword_filter_params = @filter_conditions.merge(keyword: @keyword.word, current_location: current_location_search, shop_ids: shop_ids, latitude: current_latitude, longitude: current_longitude)
+    end
     @current_page = (params[:page].to_i > 0) ? params[:page].to_i : 1
     @total_shops = shops.count
     @total_page = (@total_shops.to_f / 10).ceil

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,7 +1,7 @@
 class BookmarksController < ApplicationController
   def index
     shops = Shop.joins(:bookmarks).where(bookmarks: { user_id: current_user.id })
-    pagination(shops)
+    pagination(shops: shops)
   end
   def create
     bookmark = Bookmark.new(bookmark_params)

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -44,7 +44,13 @@ class ShopsController < ApplicationController
       shops = Shop.filter_and_keyword_association(filters, @keyword)
     end
     # ページネーション
-    pagination(shops, current_location_search, shop_ids,  current_latitude, current_longitude)
+    pagination(
+      shops: shops,
+      current_location_search: current_location_search,
+      shop_ids: shop_ids,
+      current_latitude: current_latitude,
+      current_longitude: current_longitude,
+    )
   end
 
   def show


### PR DESCRIPTION
### 概要
paginationメソッドにおいて、shopsコントローラから呼び出す時とbookmarksコントローラから呼び出す時で用いる引数が異なるため、引数にデフォルト値を設けることでエラーが起きないように修正した

### 修正内容
1. applicationコントローラのpaginationメソッドの修正
  - 引数をキーワード引数に変更
  - 以下の引数に対してデフォルト値(nil)を設定
    - current_location_search
    - current_latitude
    - current_longitude
    - shop_ids

2. shopsコントローラのpaginationメソッドに渡す引数をキーワード引数に変更

3. bookmarksコントローラのpaginationメソッドに渡す引数をキーワード引数に変更