### PR TITLE
店舗検索を行う際のクエリ数を削減

### DIFF
--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -8,4 +8,8 @@ class Filter < ApplicationRecord
   def self.find_or_create(filter)
     find_or_create_by!(filter)
   end
+
+  def self.insert_filter_condition(filter_conditions)
+    insert_all(filter_conditions)
+  end
 end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -11,40 +11,11 @@ class Shop < ApplicationRecord
   PAGE_NUMBER = 10
   DISPLAY_PAGE_RUNGE = 3
 
-
-  def self.create_or_update_from_API_data(shop_data, filter)
-    shop = find_by(unique_number: shop_data["id"])
-    if shop
-      shop.update!(
-        name: shop_data["name"],
-        address: shop_data["address"],
-        phone_number: shop_data["tel"],
-        access: shop_data["access"],
-        closing_day: shop_data["close"],
-        budget: shop_data.dig("budget", "average"),
-        number_of_seats: shop_data["capacity"],
-        url: shop_data.dig("urls", "pc"),
-        logo_image: shop_data["logo_image"],
-        image: shop_data.dig("photo", "pc", "l"),
-      )
-      shop
-    else
-      shop = create!(
-        unique_number: shop_data["id"],
-        name: shop_data["name"],
-        address: shop_data["address"],
-        phone_number: shop_data["tel"],
-        access: shop_data["access"],
-        closing_day: shop_data["close"],
-        budget: shop_data.dig("budget", "average"),
-        number_of_seats: shop_data["capacity"],
-        url: shop_data.dig("urls", "pc"),
-        logo_image: shop_data["logo_image"],
-        image: shop_data.dig("photo", "pc", "l"),
-        filter_id: filter.id,
-      )
-    end
+  def self.upsert_from_API_data(shops_data)
+    # upsert_allを使うことでデータが存在していたら更新、なければ新規登録
+    upsert_all(shops_data)
   end
+
   def self.filter_and_keyword_association(filters, keyword)
     joins(:filter, :keywords)
     .where(filters: { id: filters.ids },

--- a/app/models/shop_keyword.rb
+++ b/app/models/shop_keyword.rb
@@ -2,7 +2,7 @@ class ShopKeyword < ApplicationRecord
   belongs_to :shop
   belongs_to :keyword
 
-  def self.find_or_create_association(shop, keyword)
-    find_or_create_by!(shop_id: shop.id, keyword_id: keyword.id)
+  def self.bulk_insert(shop_keyword_data)
+    insert_all(shop_keyword_data)
   end
 end


### PR DESCRIPTION
### 概要
店舗検索を行う際に発行されるクエリの数を減らすために、
APIから取得したデータを一つずつ処理するのではなく、まとめて一括で処理を行うように変更しました

### 修正内容
1. filtersテーブルへの保存処理にinsert_allメソッドを使用
  - 全てのデータに対して一括で保存処理を行う

2. shopsテーブルへの保存処理にupsert_allメソッドを使用
  - 全てのデータに対して一括で保存or更新処理を行う

3. shop_keywordsテーブルへの保存処理にupsert_allメソッドを使用
  - 全てのデータに対して一括で保存or更新処理を行う