### PR TITLE
コメントの来店日のバリデーション設定

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,4 +4,11 @@ class Comment < ApplicationRecord
 
   validates :content, presence: true
   validates :value, presence: true
+
+  validate :data_before_today
+
+  def data_before_today
+    return if visit_day <= Date.today
+      errors.add(:visit_day, "は今日以前の日付を選択してください")
+  end
 end


### PR DESCRIPTION
### 概要
ユーザーが店舗にコメントをつける際に入力する来店日に対して、明日以降の日付が選択できないようにバリデーションルールを追加しました
明日以降の日付を選択しコメントを作成しようとするとエラーが発生し、"今日以前の日付を選択してください"とメッセージが表示されます。

<img width="1330" alt="スクリーンショット 2025-03-22 12 34 05" src="https://github.com/user-attachments/assets/1897c949-6a7d-4a51-961f-04d92bff0e01" />
