### PR TITLE
店舗評価の処理を修正

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,6 @@
 class CommentsController < ApplicationController
   def create
+    binding.pry
     shop = Shop.find(params[:shop_id])
     comment = shop.comments.new(comment_params)
     comment.user = current_user
@@ -26,7 +27,7 @@ class CommentsController < ApplicationController
       redirect_to shop_path(@shop)
     else
       flash.now[:alert] = @comment.errors.full_messages
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 
@@ -45,7 +46,7 @@ class CommentsController < ApplicationController
   def value
     @value = params[:value].to_i
     @shop = Shop.find(params[:shop_id])
-    @comment = @shop.comments.new
+    @comment = @shop.comments.find_by(id: params[:id]) || @shop.comments.new
     @comments = @shop.comments.includes(:user)
 
     render "shops/show"


### PR DESCRIPTION
### 概要
店舗評価を行う際のCommentsコントローラのvalueアクションにおいて、常に@commentに新しいコメントオブジェクトを格納するような仕組みになっていたため、以下のように変更した

params[:id]が存在する→ Commentsテーブルからデータを検索し格納
params[:id]が存在しない→新しいオブジェクトを作成し格納