### PR TITLE
unique_numberのバリデーションをDBに追加

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,5 @@
 class CommentsController < ApplicationController
   def create
-    binding.pry
     shop = Shop.find(params[:shop_id])
     comment = shop.comments.new(comment_params)
     comment.user = current_user

--- a/app/services/hotpepper_api.rb
+++ b/app/services/hotpepper_api.rb
@@ -26,7 +26,6 @@ class HotpepperApi
 
       count: count = 100
   }.compact
-binding.pry
     uri.query = URI.encode_www_form(params)
 
     response = Net::HTTP.get_response(uri) # APIにリクエストを送信

--- a/db/migrate/20250211072526_rename_image_column_to_shops.rb
+++ b/db/migrate/20250211072526_rename_image_column_to_shops.rb
@@ -1,5 +1,0 @@
-class RenameImageColumnToShops < ActiveRecord::Migration[8.0]
-  def change
-    rename_column :shops, :image, :logo_image
-  end
-end

--- a/db/migrate/20250216033141_remove_keyword_to_shops.rb
+++ b/db/migrate/20250216033141_remove_keyword_to_shops.rb
@@ -1,5 +1,0 @@
-class RemoveKeywordsToShops < ActiveRecord::Migration[8.0]
-  def change
-    remove_column :shops, :keywords
-  end
-end

--- a/db/migrate/20250324020008_add_index_to_shops_unique_number.rb
+++ b/db/migrate/20250324020008_add_index_to_shops_unique_number.rb
@@ -1,0 +1,5 @@
+class AddIndexToShopsUniqueNumber < ActiveRecord::Migration[8.0]
+  def change
+    add_index :shops, :unique_number, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_22_030103) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_24_020008) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -114,6 +114,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_22_030103) do
     t.bigint "filter_id"
     t.integer "order"
     t.index ["filter_id"], name: "fk_rails_2a05a1f881"
+    t.index ["unique_number"], name: "index_shops_on_unique_number", unique: true
   end
 
   create_table "solid_queue_blocked_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|


### PR DESCRIPTION
### 概要
shopsテーブルのunique_numberカラムに対してDBのユニーク制約(unique_index)を設定しました
これによりshopsテーブルに店舗情報が重複して保存されることを防ぐことができます
