### PR TITLE
formがnullの時の条件分岐を作成

### DIFF
--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -78,8 +78,10 @@ document.addEventListener("turbo:load", function() {
       };
     })
   }
-   form.addEventListener("submit", function(event) {
-    console.log("フォーム送信時の緯度:", latitudeField.value, "経度:", longitudeField.value);
-  });
+   if (form) {
+    form.addEventListener("submit", function(event) {
+      console.log("フォーム送信時の緯度:", latitudeField.value, "経度:", longitudeField.value);
+    });
+   }
 });
 </script>


### PR DESCRIPTION
### 概要
ブラウザのコンソールを確認するとformがnullであるのにformを呼び出していることでエラーが多発していた。
そのためformが存在する時のみ以下のコードを実行するように変更した
```
    form.addEventListener("submit", function(event) {
      console.log("フォーム送信時の緯度:", latitudeField.value, "経度:", longitudeField.value);
    });
```