### PR TITLE
renderをredirectに変更

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -24,8 +24,8 @@ class CommentsController < ApplicationController
       flash[:notice] = "コメントを編集しました"
       redirect_to shop_path(@shop)
     else
-      flash.now[:alert] = @comment.errors.full_messages
-      render :edit, status: :unprocessable_entity
+      flash[:alert] = @comment.errors.full_messages
+      redirect_to edit_shop_comment_path(@shop)
     end
   end
 


### PR DESCRIPTION
### 概要
commentsコントローラのupdateアクションにおいて、エラーが起きた際の処理を以下のように変更しました

render :edit, status: :unprocessable_entity  →  redirect_to edit_shop_comment_path(@shop)

変更理由
renderでeditファイルを再表示しようとすると、editファイル内のturbo-frameを更新することができずエラーが発生したため